### PR TITLE
Guard against no channels defined

### DIFF
--- a/lib/connector.coffee
+++ b/lib/connector.coffee
@@ -12,7 +12,7 @@ class Connector
 
   constructor: (options) ->
     @client = new Irc.Client(options.host, options.nickname, {
-      channels: options.channels.split(','),
+      channels: options.channels?.split(','),
       debug: options.debug,
       secure: options.secure,
       port: parseInt(options.port),


### PR DESCRIPTION
Fixes this error when the packaged loads

```
Failed to activate package named 'irc' TypeError: Cannot call method 'split' of undefined
  at new Connector (/Volumes/Data/Abe/Code/atom-irc/lib/connector.coffee:15:34)
```
