### PR TITLE
Allow Copying from View

### DIFF
--- a/lib/irc-view.coffee
+++ b/lib/irc-view.coffee
@@ -8,7 +8,7 @@ class IrcView extends ScrollView
   @package: null
 
   @content: ->
-    @div class: 'irc native-key-bindings', =>
+    @div class: 'irc native-key-bindings', tabindex: -1, =>
       @div class: 'input', =>
         @div '', class: 'irc-output native-key-bindings'
         @input outlet: 'ircMessage', type: 'text', class: 'irc-input native-key-bindings', placeholder: 'Enter your message...'


### PR DESCRIPTION
This is hotfix to allow copying text from inside the chat view.

Please commit this before the links pull request #23 so that i can rebase that branch. I have already tested that links still work with copying in place.