### PR TITLE
Status messages

### DIFF
--- a/lib/irc-view.coffee
+++ b/lib/irc-view.coffee
@@ -44,6 +44,7 @@ class IrcView extends ScrollView
     line.addClass 'connected' if from is 'CONNECTED'
     line.addClass 'disconnected' if from is 'DISCONNECTED'
     line.addClass 'joined' if from is 'JOINED'
+    line.addClass 'quit' if from is 'QUIT'
     line.addClass "from-#{from}"
 
     ts = $('<span>')

--- a/lib/irc-view.coffee
+++ b/lib/irc-view.coffee
@@ -41,6 +41,8 @@ class IrcView extends ScrollView
     line.addClass 'pm' if to is atom.config.get 'irc.nickname'
     line.addClass 'whois' if from is 'WHOIS'
     line.addClass 'from-me' if from is atom.config.get 'irc.nickname'
+    line.addClass 'connected' if from is 'CONNECTED'
+    line.addClass 'disconnected' if from is 'DISCONNECTED'
     line.addClass "from-#{from}"
 
     ts = $('<span>')

--- a/lib/irc-view.coffee
+++ b/lib/irc-view.coffee
@@ -43,6 +43,7 @@ class IrcView extends ScrollView
     line.addClass 'from-me' if from is atom.config.get 'irc.nickname'
     line.addClass 'connected' if from is 'CONNECTED'
     line.addClass 'disconnected' if from is 'DISCONNECTED'
+    line.addClass 'joined' if from is 'JOINED'
     line.addClass "from-#{from}"
 
     ts = $('<span>')

--- a/lib/irc.coffee
+++ b/lib/irc.coffee
@@ -75,8 +75,12 @@ module.exports =
     console.log 'Initializing IRC' if atom.config.get('irc.debug')
     @client = new Client atom.config.get('irc')
     @client
-      .on 'connected', => @ircStatusView.removeClass().addClass('connected')
-      .on 'disconnected', => @ircStatusView.removeClass()
+      .on 'connected', =>
+        @ircStatusView.removeClass().addClass('connected')
+        @ircView?.addMessage 'CONNECTED', null, 'You have successfully connected!'
+      .on 'disconnected', =>
+        @ircStatusView.removeClass()
+        @ircView?.addMessage 'DISCONNECTED', null, 'You have been disconnected.'
     @bindIrcEvents()
     @client.connect() if atom.config.get('irc.connectOnStartup')
 

--- a/lib/irc.coffee
+++ b/lib/irc.coffee
@@ -96,7 +96,7 @@ module.exports =
       .on 'abort', @errorHandler.bind @
       .on 'join', (channel, who) =>
         console.log '%s has joined %s', who, channel if atom.config.get 'irc.debug'
-        @ircView?.addMessage 'JOINED', null, who + ' has joined ' + channel
+        @ircView?.addMessage 'JOINED', null, who + ' has joined ' + channel if atom.config.get('irc.showJoinMessages')
       .on 'whois', (info) => @ircView.addMessage 'WHOIS', null, JSON.stringify info
 
   errorHandler: (message) ->

--- a/lib/irc.coffee
+++ b/lib/irc.coffee
@@ -39,6 +39,9 @@ module.exports =
     evalHtml:
       type: 'boolean'
       default: false
+    showJoinMessages:
+      type: 'boolean'
+      default: false
 
   activate: ->
     atom.workspace.addOpener (uriToOpen) =>
@@ -93,6 +96,7 @@ module.exports =
       .on 'abort', @errorHandler.bind @
       .on 'join', (channel, who) =>
         console.log '%s has joined %s', who, channel if atom.config.get 'irc.debug'
+        @ircView?.addMessage 'JOINED', null, who + ' has joined ' + channel
       .on 'whois', (info) => @ircView.addMessage 'WHOIS', null, JSON.stringify info
 
   errorHandler: (message) ->

--- a/lib/irc.coffee
+++ b/lib/irc.coffee
@@ -97,6 +97,9 @@ module.exports =
       .on 'join', (channel, who) =>
         console.log '%s has joined %s', who, channel if atom.config.get 'irc.debug'
         @ircView?.addMessage 'JOINED', null, who + ' has joined ' + channel if atom.config.get('irc.showJoinMessages')
+      .on 'quit', (who, reason) =>
+        console.log '%s has quit [%s]', who, reason if atom.config.get('irc.debug')
+        @ircView?.addMessage 'QUIT', null, who + ' has quit [' + reason + ']' if atom.config.get('irc.showJoinMessages')
       .on 'whois', (info) => @ircView.addMessage 'WHOIS', null, JSON.stringify info
 
   errorHandler: (message) ->

--- a/lib/irc.coffee
+++ b/lib/irc.coffee
@@ -94,13 +94,13 @@ module.exports =
         @ircView?.addMessage from, to, message
       .on 'error', @errorHandler.bind @
       .on 'abort', @errorHandler.bind @
-      .on 'join', (channel, who) =>
-        console.log '%s has joined %s', who, channel if atom.config.get 'irc.debug'
-        @ircView?.addMessage 'JOINED', null, who + ' has joined ' + channel if atom.config.get('irc.showJoinMessages')
-      .on 'quit', (who, reason) =>
-        console.log '%s has quit [%s]', who, reason if atom.config.get('irc.debug')
-        @ircView?.addMessage 'QUIT', null, who + ' has quit [' + reason + ']' if atom.config.get('irc.showJoinMessages')
       .on 'whois', (info) => @ircView.addMessage 'WHOIS', null, JSON.stringify info
+      if atom.config.get 'irc.showJoinMessages'
+        @client
+          .on 'join', (channel, who) =>
+            @ircView?.addMessage 'JOINED', null, who + ' has joined ' + channel 
+          .on 'quit', (who, reason) =>
+            @ircView?.addMessage 'QUIT', null, who + ' has quit [' + reason + ']'
 
   errorHandler: (message) ->
     @ircStatusView.removeClass().addClass 'error'

--- a/styles/irc.less
+++ b/styles/irc.less
@@ -14,6 +14,7 @@ span#irc-status.notify > a { color: @text-color-warning; }
     p.whois { color: @text-color-warning; }
     p.connected { color: @text-color-success; }
     p.disconnected { color: @text-color-error; }
+    p.joined { color: @text-color-info; }
     position: absolute;
     top: 0;
     bottom: 60px;

--- a/styles/irc.less
+++ b/styles/irc.less
@@ -15,6 +15,7 @@ span#irc-status.notify > a { color: @text-color-warning; }
     p.connected { color: @text-color-success; }
     p.disconnected { color: @text-color-error; }
     p.joined { color: @text-color-info; }
+    p.quit { color: @text-color-error; }
     position: absolute;
     top: 0;
     bottom: 60px;

--- a/styles/irc.less
+++ b/styles/irc.less
@@ -12,6 +12,8 @@ span#irc-status.notify > a { color: @text-color-warning; }
     p { margin-bottom: 2px; }
     p.pm { color: @text-color-success; }
     p.whois { color: @text-color-warning; }
+    p.connected { color: @text-color-success; }
+    p.disconnected { color: @text-color-error; }
     position: absolute;
     top: 0;
     bottom: 60px;


### PR DESCRIPTION
This will add status messages inside the chat output so the user knows when they connect and disconnect. Also adds a setting to turn on join messages which will output a message to the chat when someone joins the channel ( setting defaults to false to not show them ).

All of these status messages are colored in the output. I matched the connect/disconnect with the status IRC in the atom window. And join messages are blue, this way they wont be the same color as PM's which are green.

Here are the colors of the messages:

Connected: Green ( @text-color-success )
Disconnected: Red ( @text-color-error )
Joined: Blue ( @text-color-info )
